### PR TITLE
Added logging for player connection, fixed commands

### DIFF
--- a/ProxyPortalsPaper/src/main/java/dev/ogblackdiamond/proxyportals/ProxyPortals.java
+++ b/ProxyPortalsPaper/src/main/java/dev/ogblackdiamond/proxyportals/ProxyPortals.java
@@ -14,6 +14,7 @@ import io.papermc.paper.plugin.lifecycle.event.types.LifecycleEvents;
 
 
 import java.util.ArrayList;
+import java.util.logging.Logger;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -29,12 +30,13 @@ import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 
+
 /**
  *  Main class for ProxyPortals.
  */
 public class ProxyPortals extends JavaPlugin implements Listener {
 
-
+    private static final Logger LOGGER = Logger.getLogger("ProxyPortals");
     DataBase dataBase;
 
     boolean isRegistering = false;
@@ -57,8 +59,8 @@ public class ProxyPortals extends JavaPlugin implements Listener {
         Bukkit.getPluginManager().registerEvents(this, this);
 
         // register this plugin as a message sender on the "BungeeCord" channel
-        getServer().getMessenger().registerOutgoingPluginChannel(this, "BungeeCord");
-
+        this.getServer().getMessenger().registerOutgoingPluginChannel(this, "BungeeCord");
+        this.getServer().getMessenger().registerIncomingPluginChannel(this, "BungeeCord", this);
         // save config file
         saveDefaultConfig(); 
 
@@ -76,7 +78,7 @@ public class ProxyPortals extends JavaPlugin implements Listener {
         manager.registerEventHandler(LifecycleEvents.COMMANDS, event -> {
             final Commands commands = event.registrar();
             commands.register(
-                "register-portal",
+                "register-server",
                 "prepares to register a portal",
                 new Register(this)
             );
@@ -87,7 +89,7 @@ public class ProxyPortals extends JavaPlugin implements Listener {
         manager.registerEventHandler(LifecycleEvents.COMMANDS, event -> {
             final Commands commands = event.registrar();
             commands.register(
-                "deregister-portal",
+                "deregister-server",
                 "deregisters a portal",
                 new DeRegister(dataBase)
             );
@@ -176,7 +178,11 @@ public class ProxyPortals extends JavaPlugin implements Listener {
 
                 // teleports the player away to prevent repeat checks (and therefore errors)
                 player.teleport(tpLocation);
-                // sends the player to new server
+
+                //logging message sent to Velociy / BungeeCord for troubleshooting
+                LOGGER.info("Sending plugin message to BungeeCord: Connect to " + server);
+
+                //sends player to new server
                 player.sendPluginMessage(this, "BungeeCord", out.toByteArray());
             }
         }

--- a/ProxyPortalsPaper/src/main/java/dev/ogblackdiamond/proxyportals/ProxyPortals.java
+++ b/ProxyPortalsPaper/src/main/java/dev/ogblackdiamond/proxyportals/ProxyPortals.java
@@ -60,7 +60,6 @@ public class ProxyPortals extends JavaPlugin implements Listener {
 
         // register this plugin as a message sender on the "BungeeCord" channel
         this.getServer().getMessenger().registerOutgoingPluginChannel(this, "BungeeCord");
-        this.getServer().getMessenger().registerIncomingPluginChannel(this, "BungeeCord", this);
         // save config file
         saveDefaultConfig(); 
 

--- a/ProxyPortalsPaper/src/main/resources/plugin.yml
+++ b/ProxyPortalsPaper/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: ProxyPortals
-version: 1.1.0
+version: 1.1.21
 main: dev.ogblackdiamond.proxyportals.ProxyPortals 
 description: Interfaces with ProxyPortalsVelocity 
 author: BlackDiamond 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A minecraft proxy plugin that allows players to transport between servers with n
 ## Installation
 This plugin works on the backend. No need for a proxy plugin. Simply place the jar file in the plugins folder of any server you want to use portals in, and restart your server. (Note, this plugin does not need to be on the server the player is teleporting to! If you have one central lobby server that has all of the portals, that is the only server that needs the plugin.)
 
+Be sure in the `velocity.toml` file that `bungee-plugin-messaging-channel` is set to `true `
+
 ## Usage
 To register an ordinary into a server switching portal, use the command `/register-server *server*`, in which you replace `*server*` with the name of the server you want the portal to transport you to. The `*server*` parameter must be the exact same that it appears in your `velocity.toml` (you can find a list of available servers and their exact names with the `/server` command). You will be promped to walk into the portal you want to register. After you do so, the entire portal (size and shape doesn't matter) will be registered to redirect the player to that server.
 **Multiple portals can be registered to one server**!


### PR DESCRIPTION
Changed register / deregister commands to be register-server and deregister-server instead of register-portal, to reflect documentation. Added additional documentation to README for enabling messaging channel. Added logging for player connections.